### PR TITLE
simplify RunJavaUtils.py

### DIFF
--- a/RunGoogleClassroom.py
+++ b/RunGoogleClassroom.py
@@ -171,7 +171,7 @@ def main():
         tempPath = RunJavaUtils.Create_Temp_Dir()
         goldenLines = []
         if args.golden_source is not None:
-            (success, author, package, className, goldenLines) = RunJavaUtils.Copy_And_Run_Java_File(tempPath, args.goldenSource, None)
+            (success, author, package, className, goldenLines) = RunJavaUtils.Copy_And_Run_Java_File(tempPath, args.golden_source, None)
             if (success == False):
                 print("Build failure for golden source")
                 return

--- a/RunJavaUtils.py
+++ b/RunJavaUtils.py
@@ -11,14 +11,14 @@ from unittest.test import test_result
 
 
 
-def Create_Temp_Dir():    
+def Create_Temp_Dir():
     return tempfile.mkdtemp()
 
 def Clean_And_Remove_Temp_Dir(tempDir):
     shutil.rmtree(tempDir)
 
 #
-# We need the source lines to be surrounded by "    " in order for the 
+# We need the source lines to be surrounded by "    " in order for the
 # display in the .csv to be correct
 def Convert_Source_To_Excel_Compat_List(sourceName):
     try:
@@ -26,9 +26,9 @@ def Convert_Source_To_Excel_Compat_List(sourceName):
         result = sourceFile.readlines();
         sourceFile.close()
     except UnicodeDecodeError:
-        result = ["File cannot be read as text"]    
+        result = ["File cannot be read as text"]
     return result
-   
+
 def Compare_Lines(goldenList, studentList):
     maxLen = len(goldenList)
     maxLen = max(len(studentList), maxLen)
@@ -44,18 +44,18 @@ def Compare_Lines(goldenList, studentList):
         else:
             mismatch.append(" ")
     if (anyMismatch == False):
-        mismatch=["Perfect Match"]  
+        mismatch=["Perfect Match"]
     return mismatch
 #
 # This is really cheesy.  It just grabs the first line with the word package & assumes
 # that is the package name.
-# same with the className  
+# same with the className
 def Get_Java_Info(fileName):
     javaFile = io.open(fileName, "r", encoding="latin-1" )
     package = ""
     className = ""
     author = "Unknown"
-    for line in javaFile:        
+    for line in javaFile:
         if package == "":
             m = re.match(r'\s*package\s+([a-zA-Z_]\w*)\s*;', line)
             if m is not None:
@@ -77,10 +77,10 @@ def Get_Java_Info(fileName):
 def Change_Binary_To_String_List(binary):
     result=[]
     tempStr = ""
-    if (len(binary) > 0):        
+    if (len(binary) > 0):
         for a in binary:
             if (isinstance(a, str)):
-                tempStr = tempStr + a            
+                tempStr = tempStr + a
             if (a > 8 and a < 127):
                 c = chr(a)
                 if (c != '\r'):
@@ -96,12 +96,12 @@ def Change_Binary_To_String_List(binary):
     if (len(tempStr) != 0):
         tempStr = tempStr.rstrip()
         result.append(tempStr)
-        
+
     return result
- 
+
 #
 # Runs the java file from the command line.  The output is in binary format (that is what subprocess returns
-# If it doesn't run, output will be equal to a string. 
+# If it doesn't run, output will be equal to a string.
 # If we plan to keep using, probably worth fixing this so output is always a string
 def Run_Java_File(destName, package, baseName):
     className = baseName + ".class"
@@ -111,7 +111,7 @@ def Run_Java_File(destName, package, baseName):
     if (package != ""):
         os.mkdir(package)
         fullClassName = os.path.join(package, className)
-        invokeName = package + "." + invokeName            
+        invokeName = package + "." + invokeName
     try:
         subprocess.check_output(["javac", destName])
     except subprocess.CalledProcessError as e:
@@ -135,7 +135,7 @@ def Run_Java_File(destName, package, baseName):
 def Copy_And_Run_Java_File(tempDir, source, classNameArg):
     (author, package, className) = Get_Java_Info(source)
     if (classNameArg != None):
-        className = classNameArg            
+        className = classNameArg
     destName = className + ".java"
     dest = os.path.join(tempDir, destName)
     print("copying " + source + " to " + dest)
@@ -152,7 +152,7 @@ def Add_Header(values, excelWriter):
     for value in values:
         excelWriter.Add_String(value)
     excelWriter.Inc_Row()
-    
+
 def Create_Header(excelWriter, addOutput, addFile, goldLines):
     header = ["Author", "Ran"]
     if (len(goldLines) != 0):
@@ -164,9 +164,9 @@ def Create_Header(excelWriter, addOutput, addFile, goldLines):
     if (addFile):
         header.append("sourceFile")
     Add_Header(header, excelWriter)
-    
+
 def Append_Run_Data(fileName, success, author, package, className, output, source, excelWriter, addOutput, addFile, goldLines):
-        excelWriter.Add_String(author)       
+        excelWriter.Add_String(author)
         excelWriter.Add_String(str(success))
         stringLists=[]
         if (len(goldLines)):
@@ -176,25 +176,25 @@ def Append_Run_Data(fileName, success, author, package, className, output, sourc
             else:
                 stringLists.append([""])
                 stringLists.append([""])
-        if (addOutput):                            
+        if (addOutput):
             stringLists.append(output)
         for stringList in stringLists:
             excelWriter.Add_String_Array(stringList, 8)
         if (addFile and source != ""):
             excelWriter.Add_String_Array(Convert_Source_To_Excel_Compat_List(source), 4)
-        excelWriter.Inc_Row()  
+        excelWriter.Inc_Row()
 # one by one, copy the files from the source dir to the temp dir, run them,
 # and store off the results in a .csv
 def Copy_And_Run_Files(sourceDir, files, tempDir, excelWriter, addOutput, addFile, goldLines):
     Create_Header( excelWriter, addOutput, addFile, goldLines)
 
-    for file in files: 
+    for file in files:
         source = os.path.join(sourceDir, file)
         (success, author, package, className, output) = Copy_And_Run_Java_File(tempDir, source, None)
         Append_Run_Data(file, success, author, package, className, output, source, excelWriter, addOutput, addFile, goldLines)
-             
- 
-                
-    
-  
-    
+
+
+
+
+
+

--- a/RunJavaUtils.py
+++ b/RunJavaUtils.py
@@ -11,14 +11,7 @@ from unittest.test import test_result
 
 
 def Create_Temp_Dir():    
-    tempBase = os.path.join(tempfile.mkdtemp(), 'javaTemp')
-    temp = tempBase
-    tempCount = 0
-    while(os.path.exists(temp)):
-        tempCount += 1
-        temp = tempBase + str(tempCount)
-    os.mkdir(temp)
-    return temp
+    return tempfile.mkdtemp()
 
 def Clean_And_Remove_Temp_Dir(tempDir):
     dirs = os.listdir(tempDir)

--- a/RunJavaUtils.py
+++ b/RunJavaUtils.py
@@ -1,3 +1,4 @@
+import shutil
 import os
 from shutil import move
 from shutil import copyfile
@@ -14,12 +15,7 @@ def Create_Temp_Dir():
     return tempfile.mkdtemp()
 
 def Clean_And_Remove_Temp_Dir(tempDir):
-    dirs = os.listdir(tempDir)
-    for file in dirs:
-        if (file != "." and file != ".."):            
-            source = os.path.join(tempDir, file)
-            os.remove(source)
-    os.rmdir(tempDir)
+    shutil.rmtree(tempDir)
 
 #
 # We need the source lines to be surrounded by "    " in order for the 

--- a/RunJavaUtils.py
+++ b/RunJavaUtils.py
@@ -55,27 +55,22 @@ def Get_Java_Info(fileName):
     package = ""
     className = ""
     author = "Unknown"
-    authKey = "@author"
     for line in javaFile:        
-        if ("package" in line and (("import" in line) == False) and package == ""):
-            package = line.replace("package","", 1)
-            package = package.replace(" ","")
-            package = package.replace(";","")
-            package = package.strip()
-        if ("class" in line and className == ""):
-            classNamePos = line.find("class") + len("class") + 1
-            classNameList = re.split("\W+", line[classNamePos:])
-            if (len(classNameList)):
-                className = classNameList[0]
-            className = className.strip()
-            break;
-        if (authKey in line):
-            authPos = line.find(authKey)
-            authPos += len(authKey)
-            author = line[authPos:]
-            author = author.strip()
+        if package == "":
+            m = re.match(r'\s*package\s+([a-zA-Z_]\w*)\s*;', line)
+            if m is not None:
+                package = m.group(1)
+                continue
+        if className == "":
+            m = re.search(r'\bclass\s+([a-zA-Z_]\w*)\b', line)
+            if m is not None:
+                className = m.group(1)
+                break
+        m = re.search(r'@author\b(.*)$', line)
+        if m is not None:
+            author = m.group(1).strip()
     javaFile.close()
-    return (author, package, className)
+    return author, package, className
 
 
 


### PR DESCRIPTION
This patch series fixes a broken reference to `goldenSource`, simplifies functions in RunJavaUtils.py and cleans up some white space.

Some opens:
* I think the function `Change_Binary_To_String_List` can be replaced with a one liner using [`bytes.decode`](https://docs.python.org/3/library/stdtypes.html#bytes.decode), but I didn't go ahead with this because it doesn't seem to be called from anywhere. Should we remove it?
* `Clean_And_Remove_Temp_Dir` now removes the entire (possibly non-empty) temporary directory. We could take advantage of this and ignore file system clean up in the other functions, just relying on the final `rmtree` to take care of it.